### PR TITLE
Fix illegal characters and first letter missing

### DIFF
--- a/split_audio.py
+++ b/split_audio.py
@@ -43,8 +43,7 @@ def diarize_audio_with_srt(audio_file, srt_file, output_dir, padding=0.0):
 
     for i, sub in enumerate(subs):
         # Extract speaker from subtitle
-        speaker = sub.text.split(']')[0][1:]
-        speaker = re.sub(r"[<>:\"/\\|?*]+", '', speaker1)
+        speaker = re.sub(r"[[<>:\"/\\|?*]+", '', sub.text).split(']')[0]
 
         # Create speaker-specific output directory
         speaker_dir = os.path.join(output_dir, speaker)

--- a/split_audio.py
+++ b/split_audio.py
@@ -4,6 +4,7 @@ import yaml
 import pysrt
 import tkinter as tk
 import torch
+import re
 
 from tkinter import filedialog
 from pydub import AudioSegment
@@ -43,6 +44,7 @@ def diarize_audio_with_srt(audio_file, srt_file, output_dir, padding=0.0):
     for i, sub in enumerate(subs):
         # Extract speaker from subtitle
         speaker = sub.text.split(']')[0][1:]
+        speaker = re.sub(r"[<>:\"/\\|?*]+", '', speaker1)
 
         # Create speaker-specific output directory
         speaker_dir = os.path.join(output_dir, speaker)


### PR DESCRIPTION
Using this for training my models, very nice work!
I did run into an issue where with diarize enabled, speakers are sometimes named by what they say. This caused me an issue where it tried to make a file with a ? in it but then failed to find it since Windows didn't allow that.
Also, when it would name them differently, the first character was missing since it was assumed that [ would always be the first character.

Edit should fix this from happening by simply removing any of the forbidden characters.