### PR TITLE
Fixed errors in audio diarization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ conf.yaml
 
 # folders
 personal/
+venv/
 .venv/

--- a/split_audio.py
+++ b/split_audio.py
@@ -4,6 +4,8 @@ import yaml
 import pysrt
 import tkinter as tk
 import torch
+import re
+import unicodedata
 
 from tkinter import filedialog
 from pydub import AudioSegment
@@ -25,6 +27,19 @@ else:
     compute_type = "int8"
     print('CUDA is not available. Running on CPU.')
 
+def sanitize_filename(filename):
+    # Remove diacritics and normalize Unicode characters
+    normalized = unicodedata.normalize('NFKD', filename)
+    sanitized = ''.join(c for c in normalized if not unicodedata.combining(c))
+    
+    # Regular Expression to match invalid characters
+    invalid_chars_pattern = r'[<>:"/\\|?*]'
+    
+    # Replace invalid characters with an underscore
+    sanitized_filename = re.sub(invalid_chars_pattern, '_', sanitized)
+    
+    return sanitized_filename
+
 def diarize_audio_with_srt(audio_file, srt_file, output_dir, padding=0.0):
     '''
     Use whisperx generated SRT files in order to split the audio files with speaker
@@ -43,9 +58,10 @@ def diarize_audio_with_srt(audio_file, srt_file, output_dir, padding=0.0):
     for i, sub in enumerate(subs):
         # Extract speaker from subtitle
         speaker = sub.text.split(']')[0][1:]
+        sanitized_speaker = sanitize_filename(speaker)
 
         # Create speaker-specific output directory
-        speaker_dir = os.path.join(output_dir, speaker)
+        speaker_dir = os.path.join(output_dir, sanitized_speaker)
         if not os.path.exists(speaker_dir):
             os.makedirs(speaker_dir)
 


### PR DESCRIPTION
using languages other than English,
causing OS pathing errors.

I know [aotraz](https://github.com/aotraz) did use a regular expression to sort out the pathing issues, but it also needs to be normalized in order to function properly for languages such as Korean.

You could probably merge his use of the regular expression changes + my normalization changes if you've also encountered errors with non-English languages.