### PR TITLE
Remove trailing spaces and periods

### DIFF
--- a/split_audio.py
+++ b/split_audio.py
@@ -38,7 +38,15 @@ def sanitize_filename(filename):
     invalid_chars_pattern = r'[<>:"/\\|?*]'
 
     # Replace invalid characters with an underscore
-    return re.sub(invalid_chars_pattern, '_', sanitized)
+    sanitized = re.sub(invalid_chars_pattern, '_', sanitized)
+    
+		# Remove trailing spaces and periods
+    remove_trailing_periods = r'\.+$'
+    remove_trailing_spaces = r' +$'
+    sanitized = re.sub(remove_trailing_periods, '', sanitized)
+    sanitized = re.sub(remove_trailing_spaces, '', sanitized)
+    
+    return sanitized
 
 
 def get_output_filename():


### PR DESCRIPTION
Windows doesn't allow file or directory names to end with periods or spaces. I personally ran into an issue where my transcription contained segments such as "Hmm...", which resulted in an error when the script attempted to create a folder with that name with diarization enabled (unsure if this is intentional, but all of the directory names are the actual segment text with the first character chopped off, so in the case of the segment "Hmm...", it created a folder named "mm").

I also discovered another issue where long transcriptions can cause file paths to exceed the Windows limit of 256 characters, also resulting in an error. However, I did not fix that as that is beyond my knowledge but is something that should be brought up.