### PR TITLE
Specified numpy version to 1.26.4

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -7,3 +7,4 @@ pysrt
 pydub
 pyyaml
 wheel
+numpy==1.26.4

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -8,3 +8,4 @@ pysrt
 pydub
 pyyaml
 wheel
+numpy==1.26.4


### PR DESCRIPTION
Pip attempts to install latest numpy possible, which since version 2.x, breaks a lot of numpy 1.x projects. Since many dependencies in this project were written with numpy 1.x in mind, the project itself stopped working. Specifying the culprit's version should alleviate that issue.